### PR TITLE
Support message option code

### DIFF
--- a/lib/ruboty/adapters/idobata.rb
+++ b/lib/ruboty/adapters/idobata.rb
@@ -25,7 +25,11 @@ module Ruboty
       def say(message)
         pp message
         req = Net::HTTP::Post.new(idobata_messages_url.path, headers)
-        req.form_data = { 'message[room_id]' => message[:original][:room_id], 'message[source]' => message[:body], 'message[format]' => 'markdown' }
+        req.form_data = {
+          'message[room_id]' => message[:original][:room_id],
+          'message[source]'  => message[:code] ? "```\n#{message[:body]}\n```" : message[:body],
+          'message[format]'  => 'markdown'
+        }
         https = Net::HTTP.new(idobata_messages_url.host, idobata_messages_url.port)
         https.use_ssl = true
         https.start {|https| https.request(req) }


### PR DESCRIPTION
For example, a default action `help` is expected to show like this:

```
ruboty /help( me)?(?: (?<filter>.+))?\z/i - Show this help message
ruboty /ping\z/i - Return PONG to PING
ruboty /who am i\?/i - Answer who you are
```

However, the message are treated as plain text, so it is escaped and shown as below:

```
ruboty /help( me)?(?: (?.+))?\z/i - Show this help message
ruboty /ping\z/i - Return PONG to PING
ruboty /who am i\?/i - Answer who you are
```
I made that a message is shown using code blocks if option `code` is set.